### PR TITLE
Absolute Mouse Movements

### DIFF
--- a/src/gptokeyb2.h
+++ b/src/gptokeyb2.h
@@ -265,6 +265,11 @@ struct _gptokeyb_config
     int right_analog_as_mouse;
     int dpad_as_mouse;
 
+    // same as above but using absolute positional values
+    int left_analog_as_absolute_mouse;
+    int right_analog_as_absolute_mouse;
+    int dpad_as_absolute_mouse;
+
     // Amount to scroll the wheel, 0 means parent amount or default.
     Uint32 mouse_wheel_amount;
 
@@ -297,8 +302,14 @@ typedef struct
     int current_l2;
     int current_r2;
 
-    int mouse_x;
-    int mouse_y;
+    int mouse_relative_x;
+    int mouse_relative_y;
+
+    int absolute_center_x;
+    int absolute_center_y;
+    int absolute_step;
+    int mouse_absolute_x;
+    int mouse_absolute_y;
 
     int dpad_mouse_step;
     int mouse_slow_scale;
@@ -385,9 +396,16 @@ extern bool current_dpad_as_mouse;
 extern bool current_left_analog_as_mouse;
 extern bool current_right_analog_as_mouse;
 extern bool current_mouse_wheel_amount;
+extern bool current_dpad_as_absolute_mouse;
+extern bool current_left_analog_as_absolute_mouse;
+extern bool current_right_analog_as_absolute_mouse;
+
+// fds for emulated devices
+extern int xbox_uinp_fd; // fake xbox controller
+extern int kb_uinp_fd;   // fake relative mouse and keyboard
+extern int abs_uinp_fd;  // fake absolute position mouse
 
 // stuff
-extern int uinp_fd;
 extern bool xbox360_mode;
 extern bool config_mode;
 
@@ -458,12 +476,13 @@ void string_quit();
 const char *string_register(const char *string);
 
 // from og gptokeyb
-void emit(int type, int code, int val);
-void emitMouseMotion(int x, int y);
+void emit(int fd, int type, int code, int val);
+void emitRelativeMouseMotion(int x, int y);
+void emitAbsoluteMouseMotion(int x, int y);
 void emitMouseWheel(int wheel);
 void emitAxisMotion(int code, int value);
 void emitTextInputKey(int code, bool uppercase);
-void emitKey(int code, bool is_pressed, int modifier);
+void emitKey(int fd, int code, bool is_pressed, int modifier);
 void handleAnalogTrigger(bool is_triggered, bool *was_triggered, int key, int modifier);
 
 // input.c
@@ -531,12 +550,13 @@ void controller_remove_fd(Sint32 which);
 void handleInputEvent(const SDL_Event *event);
 
 // keyboard.c
-void setupFakeKeyboardMouseDevice(struct uinput_user_dev *device, int fd);
+void setupFakeKeyboardMouseDevice();
+void setupFakeAbsoluteMouseDevice();
 void handleEventBtnFakeKeyboardMouseDevice(const SDL_Event *event, bool is_pressed);
 void handleEventAxisFakeKeyboardMouseDevice(const SDL_Event *event);
 
 // xbox360.c
-void setupFakeXbox360Device(struct uinput_user_dev *device, int fd);
+void setupFakeXbox360Device();
 void handleEventBtnFakeXbox360Device(const SDL_Event *event, bool is_pressed);
 void handleEventAxisFakeXbox360Device(const SDL_Event *event);
 

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -39,24 +39,6 @@
 #include <stdio.h>
 #include <string.h>
 
-// set up absolute mouse movement ioctl incantations
-/* static void setup_abs(int fd, int type, int min, int max, int res) */
-/* { */
-/*     struct uinput_abs_setup abs = { */
-/*         .code = type, */
-/*         .absinfo = { */
-/*             .minimum = min, */
-/*             .maximum = max, */
-/*             .resolution = res */
-/*         } */
-/*     }; */
-
-/*     if (-1 == ioctl(fd, UI_ABS_SETUP, &abs)) { */
-/*         fprintf(stderr, "Error in ioctl UI_ABS_SETUP\n"); */
-/*         exit(255); */
-/*     } */
-/* } */
-
 void setupFakeAbsoluteMouseDevice()
 {
     struct uinput_user_dev device;
@@ -87,7 +69,7 @@ void setupFakeAbsoluteMouseDevice()
     ioctl(fd, UI_SET_EVBIT, EV_ABS);
 
     // magical incantations to the absolute pointer gods.
-    // These with/height/etc are all arbitrary
+    // These (width/height/etc) are all arbitrary
     device.absmin[ABS_X] = 0;
     device.absmax[ABS_X] = 1280;
     device.absfuzz[ABS_X] = 4;


### PR DESCRIPTION
This implements a mouse cursor that snaps to the position of the analog stick. Useful for aiming in some mouse-based 2d side scrollers or perhaps some 3d games where you'd like to have a "look" option.

Because the ioctl for absolute mouse movement can't be layered onto a relative mouse file descriptor, I broke out three uinput devices: xbox controller, regular mouse and keyboard, and absolute mouse.  Which device is used for which operation is a bit hard-coded at the moment but it all seems to work.