### PR TITLE
Absolute Mouse Fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ right_analog_right = clear
 right_analog_up   = mouse_wheel_up repeat
 right_analog_down = mouse_wheel_down repeat
 
+left_analog = absolute_mouse_movement
+# how many pixels of deflection before we move the pointer
+absolute_deadzone = 3
+# default is zero but set to some other angle if you have a rotated screen
+absolute_rotate = 0
+# we hardcode a 1280x960 screen here so 640x480 is dead center
+absolute_center_x = 640
+absolute_center_y = 510
+# how many pixels is maximum deflection
+absolute_step = 350
+
 [controls:analog_0]
 # Controls for devices with 0 analog sticks.
 overlay = controls

--- a/src/config.c
+++ b/src/config.c
@@ -398,19 +398,13 @@ void config_dump()
                 continue;
             }
 
-            if ((current->dpad_as_absolute_mouse != MOUSE_MOVEMENT_OFF && btn == GBTN_DPAD_UP) ||
-                (current->left_analog_as_absolute_mouse != MOUSE_MOVEMENT_OFF && btn == GBTN_LEFT_ANALOG_UP) ||
+            if ((current->left_analog_as_absolute_mouse != MOUSE_MOVEMENT_OFF && btn == GBTN_LEFT_ANALOG_UP) ||
                 (current->right_analog_as_absolute_mouse != MOUSE_MOVEMENT_OFF && btn == GBTN_RIGHT_ANALOG_UP))
             {
                 char *gbnt_name;
                 char *gbnt_mode;
 
-                if (btn == GBTN_DPAD_UP)
-                {
-                    gbnt_name = "dpad";
-                    gbnt_mode = ((current->dpad_as_absolute_mouse == MOUSE_MOVEMENT_ON) ? "mouse_absolute" : "parent");
-                }
-                else if (btn == GBTN_LEFT_ANALOG_UP)
+                if (btn == GBTN_LEFT_ANALOG_UP)
                 {
                     gbnt_name = "left_analog";
                     gbnt_mode = ((current->left_analog_as_absolute_mouse == MOUSE_MOVEMENT_ON) ? "mouse_absolute" : "parent");
@@ -516,7 +510,6 @@ void config_overlay_clear(gptokeyb_config *current)
     current->dpad_as_mouse = MOUSE_MOVEMENT_OFF;
     current->left_analog_as_mouse = MOUSE_MOVEMENT_OFF;
     current->right_analog_as_mouse = MOUSE_MOVEMENT_OFF;
-    current->dpad_as_absolute_mouse = MOUSE_MOVEMENT_OFF;
     current->left_analog_as_absolute_mouse = MOUSE_MOVEMENT_OFF;
     current->right_analog_as_absolute_mouse = MOUSE_MOVEMENT_OFF;
     current->exclusive_mode = EXL_FALSE;
@@ -538,7 +531,6 @@ void config_overlay_parent(gptokeyb_config *current)
     current->dpad_as_mouse = MOUSE_MOVEMENT_PARENT;
     current->left_analog_as_mouse = MOUSE_MOVEMENT_PARENT;
     current->right_analog_as_mouse = MOUSE_MOVEMENT_PARENT;
-    current->dpad_as_absolute_mouse = MOUSE_MOVEMENT_PARENT;
     current->left_analog_as_absolute_mouse = MOUSE_MOVEMENT_PARENT;
     current->right_analog_as_absolute_mouse = MOUSE_MOVEMENT_PARENT;
     current->exclusive_mode = EXL_PARENT;
@@ -691,7 +683,13 @@ void set_cfg_config(const char *name, const char *value, token_ctx *token_state)
         current_state.absolute_center_y = atoi_between(value, 1, 4320, 240);
 
     else if (strcasecmp(name, "absolute_step") == 0)
-        current_state.absolute_step = atoi_between(value, 1, 7680, 100);
+        current_state.absolute_step = atoi_between(value, -7680, 7680, 100);
+
+    else if (strcasecmp(name, "absolute_deadzone") == 0)
+        current_state.absolute_deadzone = atoi_between(value, 0, 100, 3);
+
+    else if (strcasecmp(name, "absolute_rotate") == 0)
+        current_state.absolute_rotate = atoi_between(value, 0, 271, 0);
 
     else if (strcasecmp(name, "mouse_scale") == 0)
         current_state.deadzone_scale = atoi_between(value, 1, 32768, 512);
@@ -811,10 +809,7 @@ static inline void set_btn_as_mouse(int btn, gptokeyb_config *config, int mode)
 
 static inline void set_btn_as_absolute_mouse(int btn, gptokeyb_config *config, int mode)
 {
-    if (GBTN_IS_DPAD(btn) || btn == GBTN_DPAD)
-        config->dpad_as_absolute_mouse = mode;
-
-    else if (GBTN_IS_LEFT_ANALOG(btn) || btn == GBTN_LEFT_ANALOG)
+    if (GBTN_IS_LEFT_ANALOG(btn) || btn == GBTN_LEFT_ANALOG)
         config->left_analog_as_absolute_mouse = mode;
 
     else if (GBTN_IS_RIGHT_ANALOG(btn) || btn == GBTN_RIGHT_ANALOG)
@@ -837,7 +832,7 @@ void set_btn_config(gptokeyb_config *config, int btn, const char *name, const ch
 
     while (token != NULL)
     {
-        // printf("%d -> %s -> %s -> %s\n", btn, name, value, token);
+        //printf("set_btn_config %d -> %s -> %s -> %s\n", btn, name, value, token);
 
         if (strlen(token) == 0)
         {

--- a/src/gptokeyb2.h
+++ b/src/gptokeyb2.h
@@ -268,7 +268,6 @@ struct _gptokeyb_config
     // same as above but using absolute positional values
     int left_analog_as_absolute_mouse;
     int right_analog_as_absolute_mouse;
-    int dpad_as_absolute_mouse;
 
     // Amount to scroll the wheel, 0 means parent amount or default.
     Uint32 mouse_wheel_amount;
@@ -305,9 +304,13 @@ typedef struct
     int mouse_relative_x;
     int mouse_relative_y;
 
+    bool absolute_invert_x;
+    bool absolute_invert_y;
     int absolute_center_x;
     int absolute_center_y;
     int absolute_step;
+    int absolute_deadzone;
+    int absolute_rotate;
     int mouse_absolute_x;
     int mouse_absolute_y;
 
@@ -396,7 +399,6 @@ extern bool current_dpad_as_mouse;
 extern bool current_left_analog_as_mouse;
 extern bool current_right_analog_as_mouse;
 extern bool current_mouse_wheel_amount;
-extern bool current_dpad_as_absolute_mouse;
 extern bool current_left_analog_as_absolute_mouse;
 extern bool current_right_analog_as_absolute_mouse;
 

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -288,14 +288,14 @@ void handleEventAxisFakeKeyboardMouseDevice(const SDL_Event *event)
         current_state.mouse_absolute_x = current_state.current_left_analog_x;
         current_state.mouse_absolute_y = current_state.current_left_analog_y;
 
-        GPTK2_DEBUG("fake absolute mouse %d %d\n", current_state.mouse_absolute_x, current_state.mouse_absolute_y);
+        //GPTK2_DEBUG("fake absolute mouse %d %d\n", current_state.mouse_absolute_x, current_state.mouse_absolute_y);
     }
     else if (current_right_analog_as_absolute_mouse && right_axis_movement)
     {
         current_state.mouse_absolute_x = current_state.current_right_analog_x;
         current_state.mouse_absolute_y = current_state.current_right_analog_y;
 
-        GPTK2_DEBUG("fake absolute mouse %d %d\n", current_state.mouse_absolute_x, current_state.mouse_absolute_y);
+        //GPTK2_DEBUG("fake absolute mouse %d %d\n", current_state.mouse_absolute_x, current_state.mouse_absolute_y);
     }
     else
     {

--- a/src/main.c
+++ b/src/main.c
@@ -454,25 +454,28 @@ int main(int argc, char* argv[])
             }
         }
 
-        if (current_state.mouse_absolute_x != 0 || current_state.mouse_absolute_y != 0 || current_dpad_as_absolute_mouse)
+        if (current_state.mouse_absolute_x != 0 || current_state.mouse_absolute_y != 0)
         {
-            mouse_x = current_state.absolute_center_x + (current_state.absolute_step * current_state.mouse_absolute_x / INT16_MAX);
-            mouse_y = current_state.absolute_center_y + (current_state.absolute_step * current_state.mouse_absolute_y / INT16_MAX);
-
-            if (current_dpad_as_absolute_mouse > 0)
-            {
-                if (is_pressed(GBTN_DPAD_LEFT))
-                    mouse_x = current_state.absolute_center_x - current_state.absolute_step;
-                if (is_pressed(GBTN_DPAD_RIGHT))
-                    mouse_x = current_state.absolute_center_x + current_state.absolute_step;
-                if (is_pressed(GBTN_DPAD_UP))
-                    mouse_y = current_state.absolute_center_y - current_state.absolute_step;
-                if (is_pressed(GBTN_DPAD_DOWN))
-                    mouse_y = current_state.absolute_center_y - current_state.absolute_step;
-            }
-
-            if (mouse_x != current_state.absolute_center_x || mouse_y != current_state.absolute_center_y) {
-                GPTK2_DEBUG("absolute mouse move to %d %d\n", mouse_x, mouse_y);
+            if (abs(mouse_x - current_state.absolute_center_x) > current_state.absolute_deadzone ||
+                abs(mouse_y - current_state.absolute_center_y) > current_state.absolute_deadzone) {
+                
+                if (current_state.absolute_rotate == 90) {
+                    mouse_x = current_state.absolute_center_x + (current_state.absolute_step * -current_state.mouse_absolute_y / INT16_MAX);
+                    mouse_y = current_state.absolute_center_y + (current_state.absolute_step * current_state.mouse_absolute_x / INT16_MAX);
+                }
+                else if (current_state.absolute_rotate == 180) { 
+                    mouse_x = current_state.absolute_center_x + (current_state.absolute_step * -current_state.mouse_absolute_x / INT16_MAX);
+                    mouse_y = current_state.absolute_center_y + (current_state.absolute_step * -current_state.mouse_absolute_y / INT16_MAX);
+                }
+                else if (current_state.absolute_rotate == 270) {
+                    mouse_x = current_state.absolute_center_x + (current_state.absolute_step * current_state.mouse_absolute_y / INT16_MAX);
+                    mouse_y = current_state.absolute_center_y + (current_state.absolute_step * -current_state.mouse_absolute_x / INT16_MAX);
+                }
+                else {
+                    mouse_x = current_state.absolute_center_x + (current_state.absolute_step * current_state.mouse_absolute_x / INT16_MAX);
+                    mouse_y = current_state.absolute_center_y + (current_state.absolute_step * current_state.mouse_absolute_y / INT16_MAX);
+                }
+                
                 emitAbsoluteMouseMotion(mouse_x, mouse_y);
                 mouse_moved=true;
             }

--- a/src/main.c
+++ b/src/main.c
@@ -456,25 +456,25 @@ int main(int argc, char* argv[])
 
         if (current_state.mouse_absolute_x != 0 || current_state.mouse_absolute_y != 0)
         {
+            if (current_state.absolute_rotate == 90) {
+                mouse_x = current_state.absolute_center_x + (current_state.absolute_step * -current_state.mouse_absolute_y / INT16_MAX);
+                mouse_y = current_state.absolute_center_y + (current_state.absolute_step * current_state.mouse_absolute_x / INT16_MAX);
+            }
+            else if (current_state.absolute_rotate == 180) { 
+                mouse_x = current_state.absolute_center_x + (current_state.absolute_step * -current_state.mouse_absolute_x / INT16_MAX);
+                mouse_y = current_state.absolute_center_y + (current_state.absolute_step * -current_state.mouse_absolute_y / INT16_MAX);
+            }
+            else if (current_state.absolute_rotate == 270) {
+                mouse_x = current_state.absolute_center_x + (current_state.absolute_step * current_state.mouse_absolute_y / INT16_MAX);
+                mouse_y = current_state.absolute_center_y + (current_state.absolute_step * -current_state.mouse_absolute_x / INT16_MAX);
+            }
+            else {
+                mouse_x = current_state.absolute_center_x + (current_state.absolute_step * current_state.mouse_absolute_x / INT16_MAX);
+                mouse_y = current_state.absolute_center_y + (current_state.absolute_step * current_state.mouse_absolute_y / INT16_MAX);
+            }
+            
             if (abs(mouse_x - current_state.absolute_center_x) > current_state.absolute_deadzone ||
                 abs(mouse_y - current_state.absolute_center_y) > current_state.absolute_deadzone) {
-                
-                if (current_state.absolute_rotate == 90) {
-                    mouse_x = current_state.absolute_center_x + (current_state.absolute_step * -current_state.mouse_absolute_y / INT16_MAX);
-                    mouse_y = current_state.absolute_center_y + (current_state.absolute_step * current_state.mouse_absolute_x / INT16_MAX);
-                }
-                else if (current_state.absolute_rotate == 180) { 
-                    mouse_x = current_state.absolute_center_x + (current_state.absolute_step * -current_state.mouse_absolute_x / INT16_MAX);
-                    mouse_y = current_state.absolute_center_y + (current_state.absolute_step * -current_state.mouse_absolute_y / INT16_MAX);
-                }
-                else if (current_state.absolute_rotate == 270) {
-                    mouse_x = current_state.absolute_center_x + (current_state.absolute_step * current_state.mouse_absolute_y / INT16_MAX);
-                    mouse_y = current_state.absolute_center_y + (current_state.absolute_step * -current_state.mouse_absolute_x / INT16_MAX);
-                }
-                else {
-                    mouse_x = current_state.absolute_center_x + (current_state.absolute_step * current_state.mouse_absolute_x / INT16_MAX);
-                    mouse_y = current_state.absolute_center_y + (current_state.absolute_step * current_state.mouse_absolute_y / INT16_MAX);
-                }
                 
                 emitAbsoluteMouseMotion(mouse_x, mouse_y);
                 mouse_moved=true;

--- a/src/state.c
+++ b/src/state.c
@@ -41,7 +41,6 @@ gptokeyb_state current_state;
 bool current_dpad_as_mouse = false;
 bool current_left_analog_as_mouse = false;
 bool current_right_analog_as_mouse = false;
-bool current_dpad_as_absolute_mouse = false;
 bool current_left_analog_as_absolute_mouse = false;
 bool current_right_analog_as_absolute_mouse = false;
 bool current_mouse_wheel_amount = DEFAULT_MOUSE_WHEEL_AMOUNT;
@@ -382,7 +381,6 @@ void state_change_update()
     bool found_dpad_as_mouse = false;
     bool found_left_analog_as_mouse = false;
     bool found_right_analog_as_mouse = false;
-    bool found_dpad_as_absolute_mouse = false;
     bool found_left_analog_as_absolute_mouse = false;
     bool found_right_analog_as_absolute_mouse = false;
     bool found_mouse_wheel_amount = false;
@@ -442,13 +440,6 @@ void state_change_update()
                 {
                     current_right_analog_as_mouse = (current->right_analog_as_mouse == MOUSE_MOVEMENT_ON);
                     found_right_analog_as_mouse = true;
-                }
-
-                // absolute positioning
-                if (!found_dpad_as_absolute_mouse && current->dpad_as_absolute_mouse != MOUSE_MOVEMENT_PARENT)
-                {
-                    current_dpad_as_absolute_mouse = (current->dpad_as_absolute_mouse == MOUSE_MOVEMENT_ON);
-                    found_dpad_as_absolute_mouse = true;
                 }
 
                 if (!found_left_analog_as_absolute_mouse && current->left_analog_as_absolute_mouse != MOUSE_MOVEMENT_PARENT)
@@ -512,13 +503,6 @@ void state_change_update()
                 found_right_analog_as_mouse = true;
             }
 
-            // absolute positioning
-            if (!found_dpad_as_absolute_mouse && current->dpad_as_absolute_mouse != MOUSE_MOVEMENT_PARENT)
-            {
-                current_dpad_as_absolute_mouse = (current->dpad_as_absolute_mouse == MOUSE_MOVEMENT_ON);
-                found_dpad_as_absolute_mouse = true;
-            }
-
             if (!found_left_analog_as_absolute_mouse && current->left_analog_as_absolute_mouse != MOUSE_MOVEMENT_PARENT)
             {
                 current_left_analog_as_absolute_mouse = (current->left_analog_as_absolute_mouse == MOUSE_MOVEMENT_ON);
@@ -565,9 +549,6 @@ void state_change_update()
 
     if (!found_right_analog_as_mouse)
         current_right_analog_as_mouse = false;
-
-    if (!found_dpad_as_absolute_mouse)
-        current_dpad_as_absolute_mouse = false;
 
     if (!found_left_analog_as_absolute_mouse)
         current_left_analog_as_absolute_mouse = false;


### PR DESCRIPTION
### Removed dpad as absolute mouse because that makes no sense
without` deflection magnitude there'd only be 8 poisitions possible for the pointer

### Added absolute_deadzone for truly terrible sticks that wobble
Apparently the Odroid Go Ultra's sticks are so bad they wiggle around and grab the mouse pointer

### added absolute_rotation for devices with rotated screens
Also Odroid Go Ultra has a rotated screen and SDL hacks to fix the pointer don't work on absolute pointers