### PR TITLE
XBox controller mode fixes (corrupted name, recursive controller input)

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -74,12 +74,17 @@ void handleInputEvent(const SDL_Event *event)
             if (controller)
             {
                 int controller_fd = interpose_get_fd();
-                const char *name = SDL_GameControllerNameForIndex(event->cdevice.which);
+                SDL_Joystick *joystick = SDL_GameControllerGetJoystick(controller);
+                const char *name = SDL_JoystickName(joystick);
                 printf("Joystick %i has game controller name '%s': %d\n", 0, name, controller_fd);
                 if (strcmp(name, XBOX_CONTROLLER_NAME) != 0)
                 {
                     SDL_GameControllerOpen(event->cdevice.which);
                     controller_add_fd(event->cdevice.which, controller_fd);
+                }
+                else
+                {
+                    SDL_GameControllerClose(controller);
                 }
             }
         }

--- a/src/xbox360.c
+++ b/src/xbox360.c
@@ -102,10 +102,7 @@ void setupFakeXbox360Device()
     UINPUT_SET_ABS_P(&device, ABS_Z, 0, 255, 0, 0);
     UINPUT_SET_ABS_P(&device, ABS_RZ, 0, 255, 0, 0);
 
-    if (-1 == ioctl(fd, UI_DEV_SETUP, device)) {
-        fprintf(stderr, "ioctl UI_DEV_SETUP");
-        exit(255);
-    }
+    write(fd, &device, sizeof(device));
 
     if (ioctl(fd, UI_DEV_CREATE)) {
         printf("Unable to create UINPUT device.");


### PR DESCRIPTION
**Revert Xbox uinput setup to deprecated method**
This fixes bugs causing the uinput device to not initialize correctly, resulting in a corrupted device name, missing ABS values and the controller not being recognised correctly by SDL2. I chose to revert back to the deprecated method rather than upgrading the rest of the setup to the new method so that CFWs on old kernels remain compatible.
**Fix fake xbox controller name filtering**
This fixes the code that was supposed to stop gptokeyb2 from reading its own controller input. SDL_GameControllerNameForIndex returns the name as specified by gamecontrollerdb.txt (Microsoft Xbox 360), not the actual device name (Microsoft X-Box 360 pad), which cause this filter to not work. Also the device needs to be closed to actually stop recieving input events from it.

Both these fixes together now enable the xbox controller mode to fully work, including l2/r2, which were broken previously.

This has been tested on muOS, ArkOS and Rocknix, with sdl2-jstest, [SDL2 Controller Tester](https://github.com/mikyll/SDL2-Controller-Tester/tree/main) and several ports: Don't Starve(Box64, SDL2), Super Hexagon(Box64, SDL2), Crop and Claw (Godot 4) and Shattered Pixel Dungeon (libGDX, GLFW)
