### PR TITLE
fix absolute mouse on muos

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -691,6 +691,12 @@ void set_cfg_config(const char *name, const char *value, token_ctx *token_state)
     else if (strcasecmp(name, "absolute_rotate") == 0)
         current_state.absolute_rotate = atoi_between(value, 0, 271, 0);
 
+    else if (strcasecmp(name, "absolute_screen_width") == 0)
+        current_state.absolute_screen_width = atoi_between(value, 1, 7680, 1920);
+
+    else if (strcasecmp(name, "absolute_screen_height") == 0)
+        current_state.absolute_screen_height = atoi_between(value, 1, 4320, 1080);
+
     else if (strcasecmp(name, "mouse_scale") == 0)
         current_state.deadzone_scale = atoi_between(value, 1, 32768, 512);
 

--- a/src/gptokeyb2.h
+++ b/src/gptokeyb2.h
@@ -311,6 +311,8 @@ typedef struct
     int absolute_step;
     int absolute_deadzone;
     int absolute_rotate;
+    int absolute_screen_width;
+    int absolute_screen_height;
     int mouse_absolute_x;
     int mouse_absolute_y;
 

--- a/src/input.c
+++ b/src/input.c
@@ -208,7 +208,7 @@ void input_init()
     size_t character_len = strlen(full_set->characters);
     const keyboard_values *keyinfo;
     memset((void*)characters, '\0', sizeof(characters));
-    char find_buff[3] = "\0\0\0";
+    char find_buff[3] = {0};
 
     for (size_t i = 0; i < character_len; i++)
     {

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -42,7 +42,7 @@
 void setupFakeAbsoluteMouseDevice()
 {
     struct uinput_user_dev device;
-    
+
     memset(&device, 0, sizeof(device));
     strncpy(device.name, "Fake Absolute Mouse", UINPUT_MAX_NAME_SIZE);
     device.id.vendor = 0x1235;  /* sample vendor */
@@ -61,28 +61,25 @@ void setupFakeAbsoluteMouseDevice()
     ioctl(fd, UI_SET_EVBIT, EV_SYN);
     ioctl(fd, UI_SET_EVBIT, EV_KEY);
     ioctl(fd, UI_SET_KEYBIT, BTN_LEFT);
+    ioctl(fd, UI_SET_KEYBIT, BTN_TOUCH);
     ioctl(fd, UI_SET_EVBIT, EV_ABS);
     ioctl(fd, UI_SET_ABSBIT, ABS_X);
     ioctl(fd, UI_SET_ABSBIT, ABS_Y);
 
-    // Fake mouse for absolute positioning
-    ioctl(fd, UI_SET_EVBIT, EV_ABS);
-
-    // magical incantations to the absolute pointer gods.
-    // These (width/height/etc) are all arbitrary
+    // Use screen dimensions as ABS range
     device.absmin[ABS_X] = 0;
-    device.absmax[ABS_X] = 1280;
-    device.absfuzz[ABS_X] = 4;
-    device.absflat[ABS_X] = 8;
+    device.absmax[ABS_X] = current_state.absolute_screen_width;
+    device.absfuzz[ABS_X] = 0;
+    device.absflat[ABS_X] = 0;
 
     device.absmin[ABS_Y] = 0;
-    device.absmax[ABS_Y] = 1024;
-    device.absfuzz[ABS_Y] = 4;
-    device.absflat[ABS_Y] = 8;
+    device.absmax[ABS_Y] = current_state.absolute_screen_height;
+    device.absfuzz[ABS_Y] = 0;
+    device.absflat[ABS_Y] = 0;
 
     // Create input device into input sub-system.  UI_DEV_SETUP is too new for arkos
     // kernel so we just write it to the fd
-    
+
     //if (-1 == ioctl(fd, UI_DEV_SETUP, device)) {
     if (-1 == write(fd, &device, sizeof(device))) {
         fprintf(stderr, "Unable to setup abs mouse device structure: %s\n", strerror(errno));

--- a/src/main.c
+++ b/src/main.c
@@ -90,6 +90,22 @@ int main(int argc, char* argv[])
         strncpy(user_config_file, "~/.config/gptokeyb2.ini", MAX_PATH);
     }
 
+    // Read display dimensions from environment for absolute mouse
+    // Note: center_x/y and step are in virtual 1280x1024 space (from config)
+    // screen_width/height are actual display dimensions (for scaling)
+    char* env_display_width = SDL_getenv("DISPLAY_WIDTH");
+    char* env_display_height = SDL_getenv("DISPLAY_HEIGHT");
+    if (env_display_width && env_display_height)
+    {
+        int width = atoi(env_display_width);
+        int height = atoi(env_display_height);
+        if (width > 0 && height > 0)
+        {
+            current_state.absolute_screen_width = width;
+            current_state.absolute_screen_height = height;
+        }
+    }
+
     // Add hotkey environment variable if available
     char* env_hotkey = SDL_getenv("HOTKEY");
     if (env_hotkey)

--- a/src/state.c
+++ b/src/state.c
@@ -82,6 +82,15 @@ void state_init()
 
     current_state.mouse_delay  = 16;
 
+    // Absolute mouse defaults
+    // Screen defaults to 640x480, config values are in virtual 1280x1024 space
+    current_state.absolute_screen_width = 640;
+    current_state.absolute_screen_height = 480;
+    current_state.absolute_center_x = 640;   // center of virtual 1280 width
+    current_state.absolute_center_y = 512;   // center of virtual 1024 height
+    current_state.absolute_step = 350;
+    current_state.absolute_deadzone = 3;
+
     controller_fds = NULL;
 
     exclusive_mode = false;


### PR DESCRIPTION
MuOS has some weird libevent stuff where it only accepts absolute pointer devices with the same resolution as the screen.  Also there's some bugs in MuOS regarding how single axis events can be submitted to libevent (they'll zero out the other axis).  So this fixes absolute mouse by sizing the coordinate resolution to match the screen resolution, and it also adds a 1 pixel wiggle when only single axes change on absolute stick movements.

I found some random Watcom tablet driver code that does similar workarounds so maybe this is a known issue in a specific version of libevent that muos happens to use.

Lastly, there's a random warning fix for newer compilers that's unrelated.