### PR TITLE
Improve fake controller detection/rejection

### DIFF
--- a/src/gptokeyb2.h
+++ b/src/gptokeyb2.h
@@ -82,6 +82,7 @@
 #define XBOX_CONTROLLER_NAME "Microsoft X-Box 360 pad"
 
 // surely this is enough. :TurtleThink: 
+#define MAX_CONTROLLERS 64
 #define MAX_CONTROL_NAME 64
 
 // THIS IS REDICULOUS, STOP IT.
@@ -551,6 +552,8 @@ void controller_add_fd(Sint32 which, int fd);
 void controller_remove_fd(Sint32 which);
 
 // event.c
+bool isExistingController(SDL_JoystickID id);
+void recordExistingControllers();
 void handleInputEvent(const SDL_Event *event);
 
 // keyboard.c

--- a/src/main.c
+++ b/src/main.c
@@ -389,6 +389,8 @@ int main(int argc, char* argv[])
         SDL_GameControllerAddMappingsFromFile(db_file);
     }
 
+    recordExistingControllers();
+
     // Create fake input devices
     if (config_mode || xbox360_mode)
     {

--- a/src/xbox360.c
+++ b/src/xbox360.c
@@ -57,9 +57,9 @@ void setupFakeXbox360Device()
     
     memset(&device, 0, sizeof(device));
     strncpy(device.name, XBOX_CONTROLLER_NAME, UINPUT_MAX_NAME_SIZE);
-    device.id.vendor = 0x045e;  /* sample vendor */
-    device.id.product = 0x028e; /* sample product */
-    device.id.version = 1;
+    device.id.vendor = 0x045e;
+    device.id.product = 0x028e;
+    device.id.version = 0x0104;
     device.id.bustype = BUS_USB;
 
     int fd = xbox_uinp_fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK);


### PR DESCRIPTION
Fixes gptk2's Xbox mode.

- Changes device version similar to GPTK1 PR 8 (https://github.com/PortsMaster/gptokeyb/pull/8) to fix D-Pad mapping issues
- Adds a new method for detecting and rejecting our own fake controller. Instead of relying on the device name reported by SDL, we now compare newly added controller to a list of existing controllers added on init. This ensures we ALWAYS detect the fake controller and other (real) Xbox controllers do not get falsely detected.

Tests:
https://docs.google.com/spreadsheets/d/1Kile6xRmJtdSbMaupQgW_iWjoHTZqy0d9_7P_V_f5VU/edit?gid=1043468637#gid=1043468637